### PR TITLE
Add sqlite-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 - [pg_top](https://github.com/markwkm/pg_top) - 'top' for PostgreSQL.
 - [pspg](https://github.com/okbob/pspg) - Postgres Pager.
 - [SQLcl](http://www.oracle.com/technetwork/developer-tools/sqlcl/overview/index.html) - Oracle SQL Developer Command Line (SQLcl) is a free command line interface for Oracle Database.
+- [sqlite-utils](https://github.com/simonw/sqlite-utils) - CLI tools for manipulating SQLite database files - inserting data, running queries, creating indexes, configuring full-text search and more.
 - [SQLLine](https://github.com/julianhyde/sqlline) - Command-line shell for issuing SQL to relational databases via JDBC.
 - [usql](https://github.com/xo/usql) - A universal command-line interface for PostgreSQL, MySQL, Oracle Database, SQLite3, Microsoft SQL Server, and many other databases including NoSQL and non-relational databases!
 


### PR DESCRIPTION
The `sqlite-utils` command-line tool provides a large array of useful functionality for working with SQLite database files: https://sqlite-utils.datasette.io/en/stable/cli.html

See also: https://simonwillison.net/series/sqlite-utils-features/