### PR TITLE
Add `wtx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 - [Sqitch](https://github.com/sqitchers/sqitch) - Sensible database-native change management for framework-free development and dependable deployment.
 - [sqldef](https://github.com/k0kubun/sqldef) - Idempotent schema management for MySQL, PostgreSQL, and more.
 - [yuniql](https://github.com/rdagumampan/yuniql) - Yet another schema versioning and migration tool just made with native .NET Core 3.0+ and hopefully better.
+- [wtx](https://github.com/c410-f3r/wtx) - A flexible schema management system written in Rust.
 
 ### Code generation
 - [ddl-generator](https://github.com/catherinedevlin/ddl-generator) - Infers SQL DDL (Data Definition Language) from table data.


### PR DESCRIPTION
`wtx` provides a flexible schema management system for different relational databases.

Files are separated into logical groups where each entry should be named using a standard structure.

```text
migrations
+-- 1__initial (Group)
    +-- 1__create_author.sql (Migration)
    +-- 2__create_post.sql (Migration)
+-- 2__fancy_stuff (Group)
    +-- 1__something_fancy.sql (Migration)
wtx.toml
```

Supports repeatable migrations, standalone CLI usage, conditional migrations and embedded deploys.

More information is available at https://c410-f3r.github.io/wtx/database/schema-management.html.