### PR TITLE
add ChartDB to Documentations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 - [QuickDBD](https://www.quickdatabasediagrams.com/) - Simple online tool to quickly draw database diagrams.
 
 ### Documentations
+- [ChartDB](https://github.com/chartdb/chartdb) - Open-source web-based database diagrams editor.
 - [dbdocs](https://dbdocs.io/) - Create web-based database documentation using DSL code.
 - [DBML](https://github.com/holistics/dbml) - Database Markup Language, designed to define and document database structures.
 - [SchemaCrawler](https://github.com/schemacrawler/SchemaCrawler) - A free database schema discovery and comprehension tool.


### PR DESCRIPTION

- I have read and understood the contribution.MD file

- [ChartDB website](https://chartdb.io) but in the README.md I linked to the Github project.