### PR TITLE
Add Conflict Serializable Validator to Schema > Diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 ### Diagrams
 - [Azimutt](https://github.com/azimuttapp/azimutt) - An Entity Relationship diagram (ERD) visualization tool, with various filters and inputs to help understand your database schema.
 - [ChartDB](https://github.com/chartdb/chartdb) - Free and Open-source database diagrams editor, visualize and design your DB with a single query.
+- [Conflict Serializable Validator](https://github.com/coderatul/conflict-serializable-validator) - Checks transaction schedules for conflict serializability with dependency graph visualization.
 - [DrawDB](https://github.com/drawdb-io/drawdb) - Free, simple, and intuitive online database design tool and SQL generator. 
 - [ERAlchemy](https://github.com/Alexis-benoist/eralchemy) - Entity Relation Diagrams generation tool.
 - [ERD Lab](https://www.erdlab.io/) - Free cloud based entity relationship diagram (ERD) tool made for developers.


### PR DESCRIPTION
Adds, Conflict Serializable Validator to the Schema > Diagrams section. It’s a Python tool that checks if transaction schedules are conflict serializable by building and visualizing dependency graphs using `networkx` and `matplotlib`.

- Link: https://github.com/coderatul/conflict-serializable-validator
- One link submitted as per guidelines.
- Entry added alphabetically with no trailing whitespace.