### PR TITLE
Add pg-walstream to PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ Useful SQL-scripts for various purposes
 - [pg_chameleon](https://github.com/the4thdoctor/pg_chameleon) - MySQL to PostgreSQL replica system written in Python 3. The system use the library mysql-replication to pull the row images from MySQL which are stored into PostgreSQL as JSONB.
 - [PGDeltaStream](https://github.com/hasura/pgdeltastream) - A Golang webserver to stream PostgreSQL changes atleast-once over websockets, using PostgreSQL logical decoding feature.
 - [repmgr](https://github.com/2ndQuadrant/repmgr) - The Most Popular Replication Manager for PostgreSQL.
+- [pg-walstream](https://github.com/isdaniel/pg-walstream) - A Rust library for streaming PostgreSQL WAL using the logical replication protocol.
+
 
 ### Compare
 - [data-diff](https://github.com/datafold/data-diff) - Command-line tool and Python library to efficiently diff rows across two different databases.


### PR DESCRIPTION
Adding Rust library for streaming PostgreSQL WAL using the logical replication protocol. ([Source Code](https://github.com/isdaniel/pg-walstream))