### PR TITLE
Add migrationpilot to Schema Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 - [gh-ost](https://github.com/github/gh-ost) - Online schema migration for MySQL.
 - [liquibase](https://github.com/liquibase/liquibase) - Database-independent library for tracking, managing and applying database schema changes.
 - [migra](https://github.com/djrobstep/migra) - Like diff but for PostgreSQL schemas.
+- [migrationpilot](https://github.com/mickelsamuel/migrationpilot) - PostgreSQL migration safety linter with 80 rules for lock hazards, unsafe DDL, and risk scoring. CLI + GitHub Action.
 - [node-pg-migrate](https://github.com/salsita/node-pg-migrate) - Node.js database migration management built exclusively for PostgreSQL. (But can also be used for other DBs conforming to SQL standard - e.g. CockroachDB.)
 - [pg-osc](https://github.com/shayonj/pg-osc) - Easy CLI tool for making zero downtime schema changes and backfills in PostgreSQL.
 - [Prisma Migrate](https://github.com/prisma/migrate) - Declarative database schema migration tool that uses a declarative data modeling syntax to describe your database schema.


### PR DESCRIPTION
Adds [migrationpilot](https://github.com/mickelsamuel/migrationpilot) to the **Schema > Changes** section.

**What it is:** A PostgreSQL migration safety linter — CLI + GitHub Action that analyzes DDL for lock hazards, unsafe operations, and risk scoring.

- **80 safety rules** covering lock hazards, data safety, and best practices
- **Lock type classification** — identifies which lock level each operation acquires
- **Auto-fix** — suggests safe multi-step patterns for 12 dangerous operations
- **Risk scoring** — prioritizes which migrations to fix first
- **GitHub Action** — free CI integration for PR checks
- **MIT licensed**, free and open source

GitHub: https://github.com/mickelsamuel/migrationpilot
npm: https://www.npmjs.com/package/migrationpilot