### PR TITLE
Add MigrationPilot to Schema > Changes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 - [gh-ost](https://github.com/github/gh-ost) - Online schema migration for MySQL.
 - [liquibase](https://github.com/liquibase/liquibase) - Database-independent library for tracking, managing and applying database schema changes.
 - [migra](https://github.com/djrobstep/migra) - Like diff but for PostgreSQL schemas.
+- [MigrationPilot](https://github.com/mickelsamuel/migrationpilot) - PostgreSQL migration safety CLI that catches dangerous DDL before production — 80 rules, lock classification, auto-fix, GitHub Action.
 - [node-pg-migrate](https://github.com/salsita/node-pg-migrate) - Node.js database migration management built exclusively for PostgreSQL. (But can also be used for other DBs conforming to SQL standard - e.g. CockroachDB.)
 - [pg-osc](https://github.com/shayonj/pg-osc) - Easy CLI tool for making zero downtime schema changes and backfills in PostgreSQL.
 - [Prisma Migrate](https://github.com/prisma/migrate) - Declarative database schema migration tool that uses a declarative data modeling syntax to describe your database schema.


### PR DESCRIPTION
Adds [MigrationPilot](https://github.com/mickelsamuel/migrationpilot) — a PostgreSQL migration safety CLI that catches dangerous DDL before production.

- 80 safety rules covering lock hazards, data safety, and best practices
- Lock type classification for each DDL operation
- Auto-fix suggestions with safe multi-step migration patterns
- Free GitHub Action for CI/CD integration
- MIT licensed, open source

Placed in the Schema > Changes section alongside migra, node-pg-migrate, and other migration tools.