### PR TITLE
Add DBX Studio to IDE section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 - [dbForge Studio for PostgreSQL](https://www.devart.com/dbforge/postgresql/studio) - GUI tool for managing and developing databases and objects.
 - [dbForge Studio for SQL Server](https://www.devart.com/dbforge/sql/studio) - Powerful integrated development environment for SQL Server development, management, administration, data analysis, and reporting.
 - [DBHawk](https://www.datasparc.com/) - Datasparc offers database security, database management, database governance and data analytics - all in one solution.
+- [DBX Studio](https://github.com/Dbxstudio/dbx-studio) - Open-source database IDE with AI chat, SQL editor, and data visualization. Connect to PostgreSQL, MySQL, SQLite, Snowflake, Redshift, and more.
 - [dbKoda](https://github.com/SouthbankSoftware/dbkoda) - Modern (JavaScript/Electron framework), open source IDE for MongoDB. It has features to support development, administration and performance tuning on MongoDB databases.
 - [IBExpert](http://www.ibexpert.net/ibe) - Comprehensive GUI tool for Firebird and InterBase.
 - [HeidiSQL](https://github.com/HeidiSQL/HeidiSQL) - A lightweight client for managing MySQL, MSSQL and PostgreSQL, written in Delphi.


### PR DESCRIPTION
Adding [DBX Studio](https://github.com/Dbxstudio/dbx-studio) — an open-source database IDE with AI chat, SQL editor, and data visualization. Supports PostgreSQL, MySQL, SQLite, Snowflake, Amazon Redshift, Supabase, and MSSQL. Apache 2.0 licensed.