### PR TITLE
Add Panopticum

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 
 
 ## GUI
+- [Panopticum](https://github.com/theSharque/panopticum) - Dev/QA web tool for DB operations (PostgreSQL, MySQL, MongoDB, Redis, ClickHouse, etc.) in Kubernetes with MCP interface.
 - [Adminer](https://github.com/vrana/adminer) - Database management in a single PHP file.
 - [Another Redis Desktop Manager](https://github.com/qishibo/AnotherRedisDesktopManager) - Free Open Source Redis Manager. Available on Mac, Linux, Windows, Homebrew, Snap, winget, and more.
 - [Antares SQL](https://github.com/antares-sql/antares) - A modern, fast and productivity driven SQL client with a focus in UX. Available for Mac, Linux and Windows.


### PR DESCRIPTION
Add [Panopticum](https://github.com/theSharque/panopticum) - Dev/QA tool for DB operations (MongoDB, Redis, ClickHouse, PostgreSQL) in Kubernetes with MCP interface.