### PR TITLE
Add Yaw Terminal to GUI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 - [TablePlus](https://github.com/TablePlus/TablePlus) - Modern, native, and friendly GUI tool for relational databases: MySQL, PostgreSQL, SQLite & more.
 - [TeamPostgreSQL](http://www.teampostgresql.com) - PostgreSQL Web Administration GUI - use your PostgreSQL databases from anywhere, with rich, lightning-fast AJAX web interface.
 - [Query.me](https://query.me) - Collaborative SQL editor in Notebook format. Let's you reference query results using JINJA, visualize data, and schedule runs and exports.
+- [Yaw Terminal](https://yaw.sh) - Terminal with built-in database clients for PostgreSQL, MySQL, SQL Server, MongoDB, and Redis.
 
 
 ## CLI


### PR DESCRIPTION
Adds [Yaw Terminal](https://yaw.sh) to the GUI section — a terminal with built-in database clients for PostgreSQL, MySQL, SQL Server, MongoDB, and Redis.