### PR TITLE
Add squix

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 - [SQLcl](http://www.oracle.com/technetwork/developer-tools/sqlcl/overview/index.html) - Oracle SQL Developer Command Line (SQLcl) is a free command line interface for Oracle Database.
 - [sqlite-utils](https://github.com/simonw/sqlite-utils) - CLI tools for manipulating SQLite database files - inserting data, running queries, creating indexes, configuring full-text search and more.
 - [SQLLine](https://github.com/julianhyde/sqlline) - Command-line shell for issuing SQL to relational databases via JDBC.
+- [squix](https://github.com/eduardofuncao/squix) - SQL command-line client with query management and interactive results.
 - [usql](https://github.com/xo/usql) - A universal command-line interface for PostgreSQL, MySQL, Oracle Database, SQLite3, Microsoft SQL Server, and many other databases including NoSQL and non-relational databases!
 
 ### dbcli


### PR DESCRIPTION
- [x] I have read and understood the contribution.MD file

Repo: https://github.com/eduardofuncao/squix

Description: SQL command-line client with interactive results, query management and schema explorer for sqlite, postgres, oracle and others.

Reusable workflow for SQL databases: save queries with aliases, rerun them easily, and explore query results interactively (update, delete, search and export data) without leaving the terminal, in a single Go binary.

PS. I added squix to the CLI list since it's a command line tool at its core. But it has a TUI query results view. If it should be in the GUI list, please let me know and I'll fix the PR. Thanks a lot for considering adding squix!