### PR TITLE
Add neond to Application platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Low-code and no-code platforms for application building
 - [Budibase](https://github.com/Budibase/budibase) - Low-code platform for creating internal apps in minutes.
 - [ILLA Cloud](https://github.com/illacloud/illa-builder) - Low-code internal tool building platform.
 - [Nhost](https://github.com/nhost/nhost) - The Open Source Firebase Alternative with GraphQL.
+- [neond](https://github.com/matisiekpl/neond) - DX-focused control plane for Postgres with branching, PITR, and S3-backed storage; ships as a single Docker container.
 - [Saltcorn](https://github.com/saltcorn/saltcorn) - Open source no-code builder for web datatabase applications. Server and drag-and-drop UI builder, data stored in PostgreSQL or SQLite.
 - [SQLPage](https://github.com/sqlpage/SQLPage) - Fast SQL-only data application builder. Automatically build a UI on top of SQL queries.
 - [Tooljet](https://github.com/ToolJet/ToolJet) - Open-source low-code platform to build internal tools.


### PR DESCRIPTION
## Description

Adding neond to the Application platforms section — an open-source, DX-focused control plane for Postgres with branching, PITR, and S3-backed storage.

GitHub: https://github.com/matisiekpl/neond
License: Apache 2.0
Actively maintained

## Checklist

- [x] Entry is added in alphabetical order
- [x] Format matches existing entries (name, URL, one-sentence description)
- [x] Link goes to the GitHub repo (not a commercial page)
- [x] Project is open source with a valid license
- [x] Description is concise and factual