### PR TITLE
Add dakera-cli to CLI — Rust CLI for self-hosted agent memory management

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 - [pg_activity](https://github.com/julmon/pg_activity) - Top-like application for PostgreSQL server activity monitoring.
 - [pg_top](https://github.com/markwkm/pg_top) - Top for PostgreSQL.
 - [pspg](https://github.com/okbob/pspg) - PostgreSQL Pager.
+- [dakera-cli](https://github.com/dakera-ai/dakera-cli) - Cross-platform Rust CLI for managing self-hosted agent memory. Query, store, decay-configure, and export memories from your Dakera memory server.
 - [diesel-guard](https://github.com/ayarotsky/diesel-guard) - Linter for dangerous PostgreSQL migration patterns. It works seamlessly with PostgreSQL SQL files and integrates natively with projects using Diesel and SQLx.
 - [SQLcl](http://www.oracle.com/technetwork/developer-tools/sqlcl/overview/index.html) - Oracle SQL Developer Command Line (SQLcl) is a free command line interface for Oracle Database.
 - [sqlite-utils](https://github.com/simonw/sqlite-utils) - CLI tools for manipulating SQLite database files - inserting data, running queries, creating indexes, configuring full-text search and more.


### PR DESCRIPTION
## What

Adds [dakera-cli](https://github.com/dakera-ai/dakera-cli) to the CLI section.

## Why

`dakera-cli` is a cross-platform command-line interface for managing a self-hosted Dakera agent memory server. It is written in Rust and provides first-class terminal access to memory operations that are otherwise handled via the MCP protocol in AI agent contexts.

Key capabilities:
- Query and store agent memories from the terminal
- Configure decay schedules (how quickly memories fade over time)
- Export memory snapshots for backup or migration
- Inspect namespaces and session history
- Works with any self-hosted Dakera instance

It targets developers and ops teams who want scriptable, non-agent access to their memory infrastructure — useful for auditing, maintenance, and integration testing.