### PR TITLE
Add DBX to GUI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ For updates on `awesome-db-tools` and thoughts/news about databases/tools/SQL fo
 - [Clidey WhoDB](https://github.com/clidey/whodb) - A lightweight database explorer with next-gen UX for all SQL, NoSQL, Caches, and Queues.
 - [DbGate](https://github.com/dbgate/dbgate) - Database manager for MySQL, PostgreSQL, SQL Server, MongoDB, SQLite and others. Runs under Windows, Linux, Mac or as web application.
 - [DB Lens](https://github.com/dblens/app) - Open Source PostgreSQL GUI - Automatic ER diagrams, Internal DB Insights, Disk Utilisation, Performance Metrics, Index Usage, Sequential scan counts and more.
+- [DBX](https://github.com/t8y2/dbx) - Lightweight cross-platform database workspace with SQL editing, data grids, schema tools, and AI assistance.
 - [DbVisualizer](https://www.dbvis.com) - Universal database tool for developers, DBAs and analysts.
 - [JackDB](https://www.jackdb.com) - Direct SQL access to all your data, no matter where it lives.
 - [Jailer](https://github.com/Wisser/Jailer) - Database Subsetting and Relational Data Browsing Tool/Client.


### PR DESCRIPTION
Adds DBX to the GUI section.

DBX here is https://github.com/t8y2/dbx, a lightweight cross-platform database workspace built with Tauri. This is distinct from the separate DBX Studio project mentioned in another open PR.