### PR TITLE
Add OneQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Low-code and no-code platforms for application building
 - [Acra](https://github.com/cossacklabs/acra) - Database security suite. Database proxy with field-level encryption, search through encrypted data, SQL injections prevention, intrusion detection, honeypots. Supports client-side and proxy-side ("transparent") encryption. SQL, NoSQL.
 - [Databunker](https://github.com/securitybunker/databunker) - Special GDPR compliant secure vault for customer records built on top of regular DB.
 - [Inspektor](https://github.com/poonai/inspektor) - Access control layer for databases. Inspektor leverages open policy agent to make policy decisions.
+- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted data access gateway for databases, analytics tools, and APIs with centralized credentials, read-only query validation, query limits, and audit logs.
 
 
 ## SQL

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Low-code and no-code platforms for application building
 - [Acra](https://github.com/cossacklabs/acra) - Database security suite. Database proxy with field-level encryption, search through encrypted data, SQL injections prevention, intrusion detection, honeypots. Supports client-side and proxy-side ("transparent") encryption. SQL, NoSQL.
 - [Databunker](https://github.com/securitybunker/databunker) - Special GDPR compliant secure vault for customer records built on top of regular DB.
 - [Inspektor](https://github.com/poonai/inspektor) - Access control layer for databases. Inspektor leverages open policy agent to make policy decisions.
-- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted data access gateway for databases, analytics tools, and APIs with centralized credentials, read-only query validation, query limits, and audit logs.
+- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted gateway for safe, auditable agent queries across approved data sources.
 
 
 ## SQL

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Low-code and no-code platforms for application building
 - [Acra](https://github.com/cossacklabs/acra) - Database security suite. Database proxy with field-level encryption, search through encrypted data, SQL injections prevention, intrusion detection, honeypots. Supports client-side and proxy-side ("transparent") encryption. SQL, NoSQL.
 - [Databunker](https://github.com/securitybunker/databunker) - Special GDPR compliant secure vault for customer records built on top of regular DB.
 - [Inspektor](https://github.com/poonai/inspektor) - Access control layer for databases. Inspektor leverages open policy agent to make policy decisions.
-- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted gateway for safe, auditable agent queries across approved data sources.
+- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted gateway for safe, auditable queries for agents across approved data sources.
 
 
 ## SQL


### PR DESCRIPTION
# Requirements for your pull request
- I have read and understood the contribution.MD file

Adds OneQuery to the Security section.

OneQuery is a self-hosted gateway for safe, auditable queries for agents across approved data sources.

Guideline check:
- One link in this PR.
- Link works and no duplicate OneQuery entry was found before submission.
- Description is short, neutral, and follows the existing list format.
- Disclosure: I am affiliated with Wordbricks/OneQuery.